### PR TITLE
State the conference year

### DIFF
--- a/actdocs/conf/act.ini
+++ b/actdocs/conf/act.ini
@@ -3,7 +3,7 @@ full_uri  = http://act.yapc.eu/lpw2019/
 languages = en
 default_language = en
 default_country  = uk
-name_en   = London Perl Workshop 
+name_en   = London Perl Workshop 2019
 timezone  = Europe/London
 
 [registration]


### PR DESCRIPTION
I assume this will cause our pages to have the year in their title, which seems good from a usability, bookmarking and SEO perspective.