### PR TITLE
Expand title

### DIFF
--- a/actdocs/templates/ui
+++ b/actdocs/templates/ui
@@ -14,7 +14,7 @@
     <link rel="stylesheet" type="text/css" href="[% make_uri_info('css', 'style.css') %]?v=1" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="[% make_uri_info('js', 'jquery-3.4.1.slim.min.js') %]"></script>
-    <title>[% global.conference.name %][% IF title %] | [% title  %][% END %]</title>
+    <title>[% global.conference.name %] | [% IF title; title; ELSE %]Perl workshop and training in London[% END %]</title>
 [% PROCESS custom/jsonld %]
   </head>
   <body>


### PR DESCRIPTION
I'm hoping that a more detailed title tag will stop Google thinking that the LPW is in Glasgow.
This way, the text will only appear on pages that don't have their own title (like the home page - which is where it is important).