### PR TITLE
Link to the approved talks

### DIFF
--- a/actdocs/static/index.html
+++ b/actdocs/static/index.html
@@ -13,7 +13,7 @@ The London Perl Workshop (LPW) is a free one-day technical conference in Central
     </ul>
 </p>
 
-<p>Run by volunteers from the London Perl Community, LPW covers Perl 5, Perl 6 and other languages, technologies and topics. Last year we had talks on Go, BDD and mentoring developers to name just a few.<p> 
+<p>Run by volunteers from the London Perl Community, LPW covers Perl 5, Perl 6 and other languages, technologies and topics. We have already started approving some of <a href="[% make_uri('talks') %]">this year's talks</a>.<p> 
 
 <p>The LPW is an inclusive event and we would love to have you attend, whether this is your first time learning about Perl, or your 14th workshop. We encourage attendees and speakers from people of any age, background or circumstance, and we are open to receiving proposals for talks on any subject you think your fellow attendees will find interesting.</p>
 


### PR DESCRIPTION
Instead of saying what people have talked about in the past, show what they're going to talk about this year.