### PR TITLE
Load the map lazily

### DIFF
--- a/actdocs/static/index.html
+++ b/actdocs/static/index.html
@@ -61,7 +61,7 @@ The London Perl Workshop (LPW) is a free one-day technical conference in Central
 
 <a name="map"></a>
 <div id=map>
-	<iframe src="https://www.google.com/maps/d/u/0/embed?mid=1DYK_2kbbyIDWh0xcEnAJe-mUgsfemHJu" width="640" height="480"></iframe>
+	<iframe src="https://www.google.com/maps/d/u/0/embed?mid=1DYK_2kbbyIDWh0xcEnAJe-mUgsfemHJu" width="640" height="480" loading="lazy"></iframe>
 </div>
 
 [% END %]


### PR DESCRIPTION
The map at the bottom of the screen is very important, but is way below the fold. This commit makes Chrome-based browsers load the iframe lazily. This means that the first view of the page will be fast, but as the user scrolls down, the map will load before it is visible.